### PR TITLE
Restructure amr parsing

### DIFF
--- a/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
+++ b/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
@@ -92,7 +92,7 @@ def main(
         # Attempting to AMR-parse an empty list yields an error
         if not tokenized_sentences:
             continue
-        amr_parse = amr_parser.amr_parse_sentences(tokenized_sentences)
+        amr_parse = amr_parser.amr_parse_sentences_for_document(tokenized_sentences)
 
         output_file = f"{output_dir}/{input_file.stem}.amr"
         with open(output_file, "w+", encoding="utf-8") as outfile:

--- a/cdse_covid/semantic_extraction/models/amr.py
+++ b/cdse_covid/semantic_extraction/models/amr.py
@@ -40,12 +40,12 @@ class AMRModel(object):
         return cls(parser)
 
     def amr_parse_sentences_for_document(
-        self, sentence: List[List[str]], output_alignments: bool = False
+        self, sentences: List[List[str]], output_alignments: bool = False
     ) -> Optional[AMROutput]:
         """Parse sentences in AMR graph and alignments."""
         logging.info(output_alignments)
         try:
-            annotations = self.parser.parse_sentences(sentence)
+            annotations = self.parser.parse_sentences(sentences)
         except IndexError as e:
             logging.warning(e)
             return None

--- a/wikidata_linker/linker.py
+++ b/wikidata_linker/linker.py
@@ -57,7 +57,7 @@ class WikidataLinkingClassifier(torch.nn.Module):
             paired_text,
             pad_to_max_length=True,
             truncation=True,
-            max_length=528,
+            max_length=256,
             add_special_tokens=True,
             return_tensors="pt",
         ).to(self.model.device)


### PR DESCRIPTION
Partly addresses https://github.com/isi-vista/cdse-covid/issues/195 by
* Running the AMR parsing on all sentences/claims before the semantic extraction
* Reducing the max length for the Wikidata classifier's tokenizer