### PR TITLE
Order claims in ISI json output

### DIFF
--- a/cdse_covid/pegasus_pipeline/convert_claims_to_json.py
+++ b/cdse_covid/pegasus_pipeline/convert_claims_to_json.py
@@ -24,6 +24,7 @@ def main(input_dir: Path, output: Path) -> None:
 
     claims = ClaimDataset.load_from_key_value_store(input_dir)
     structured_claims = [structure_claim(claim) for claim in claims]
+    structured_claims.sort(key=lambda x: x["doc_id"])
     output.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output, "w+", encoding="utf-8") as handle:

--- a/cdse_covid/pegasus_pipeline/convert_claims_to_json.py
+++ b/cdse_covid/pegasus_pipeline/convert_claims_to_json.py
@@ -24,7 +24,7 @@ def main(input_dir: Path, output: Path) -> None:
 
     claims = ClaimDataset.load_from_key_value_store(input_dir)
     structured_claims = [structure_claim(claim) for claim in claims]
-    structured_claims.sort(key=lambda x: x["doc_id"])
+    structured_claims.sort(key=lambda x: (x["doc_id"], x["claim_id"]))
     output.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output, "w+", encoding="utf-8") as handle:

--- a/cdse_covid/pegasus_pipeline/ingesters/uiuc_claims_ingester.py
+++ b/cdse_covid/pegasus_pipeline/ingesters/uiuc_claims_ingester.py
@@ -49,7 +49,7 @@ def main(claims_file: Path, output: Path, spacy_model: Language) -> None:
                     )  # Should account for whitespace
 
             new_claim = Claim(
-                claim_id=create_id(),
+                claim_id=claim["claim_id"],
                 doc_id=doc_id,
                 claim_text=claim["claim_span_text"],
                 claim_span=(


### PR DESCRIPTION
Closes #200 
Because of the way that the claim data is read in during the AIF conversion, the quickest solution appeared to be sorting the claim data in the json file by document ID.