### PR TITLE
Faster linking

### DIFF
--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -37,6 +37,7 @@ def main(
     parser_path: Path,
     state_dict: Path,
     domain: str,
+    max_batch_size: int = 8,
     device: str = CPU,
 ) -> None:
     """Entrypoint to AMR parsing script."""
@@ -117,6 +118,7 @@ def main(
                 linking_model,
                 wordnet_lemmatizer,
                 qnode_mappings,
+                max_batch_size,
                 device,
             )
             if best_qnode:
@@ -149,6 +151,7 @@ def main(
             linking_model,
             wordnet_lemmatizer,
             qnode_mappings,
+            max_batch_size,
             device,
         )
         claim.claim_semantics = semantics
@@ -171,6 +174,9 @@ if __name__ == "__main__":
         "--max-tokens", help="Max tokens allowed in a sentence to be parsed", type=int, default=50
     )
     parser.add_argument("--domain", help="`covid` or `general`", type=str, default="general")
+    parser.add_argument(
+        "--max-batch-size", help="Max batch size; 8 is recommended", type=int, default="8"
+    )
     parser.add_argument("--device", help="cpu or cuda", type=str, default=CPU)
 
     args = parser.parse_args()
@@ -185,5 +191,6 @@ if __name__ == "__main__":
         parser_path=args.amr_parser_model,
         state_dict=args.state_dict,
         domain=args.domain,
+        max_batch_size=args.max_batch_size,
         device=args.device,
     )

--- a/cdse_covid/semantic_extraction/run_wikidata_linking.py
+++ b/cdse_covid/semantic_extraction/run_wikidata_linking.py
@@ -16,7 +16,12 @@ from wikidata_linker.wikidata_linking import CPU
 
 
 def main(
-    claim_input: Path, state_dict: Path, output: Path, spacy_model: Language, device: str = CPU
+    claim_input: Path,
+    state_dict: Path,
+    output: Path,
+    spacy_model: Language,
+    max_batch_size: int = 8,
+    device: str = CPU,
 ) -> None:
     """Entry point to linking script."""
     logging.basicConfig()
@@ -48,6 +53,7 @@ def main(
                     linking_model,
                     lemmatizer,
                     qnode_tables,
+                    max_batch_size,
                     device,
                 )
                 if best_qnode:
@@ -67,10 +73,13 @@ if __name__ == "__main__":
     parser.add_argument("--claim-input", type=Path)
     parser.add_argument("--state-dict", type=Path, help="Path to `wikidata_classifier.state_dict`")
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--max-batch-size", help="Max batch size; 8 is recommended", type=int, default="8"
+    )
     parser.add_argument("--device", type=str, default="cpu")
 
     args = parser.parse_args()
 
     model = spacy.load("en_core_web_md")
 
-    main(args.claim_input, args.state_dict, args.output, model, args.device)
+    main(args.claim_input, args.state_dict, args.output, model, args.max_batch_size, args.device)

--- a/wikidata_linker/linker.py
+++ b/wikidata_linker/linker.py
@@ -55,7 +55,7 @@ class WikidataLinkingClassifier(torch.nn.Module):
         paired_text = [(text, qnode_text) for qnode_text in qnode_texts]
         encoded_input = self.tokenizer.batch_encode_plus(
             paired_text,
-            pad_to_max_length=True,
+            padding="max_length",
             truncation=True,
             max_length=256,
             add_special_tokens=True,

--- a/wikidata_linker/linker.py
+++ b/wikidata_linker/linker.py
@@ -55,9 +55,7 @@ class WikidataLinkingClassifier(torch.nn.Module):
         paired_text = [(text, qnode_text) for qnode_text in qnode_texts]
         encoded_input = self.tokenizer.batch_encode_plus(
             paired_text,
-            padding="max_length",
-            truncation=True,
-            max_length=256,
+            padding=True,
             add_special_tokens=True,
             return_tensors="pt",
         ).to(self.model.device)


### PR DESCRIPTION
Further reduces wikidata linking time by making the max input length in a batch the same as the longest input in that batch (instead of `256`).
Also makes `max_batch_size` configurable.